### PR TITLE
Upgrade Swrve version from 4.+ to 5.+ and resolve breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To install the Segment-Swrve integration, simply add this line to your gradle fi
 ```
 dependencies {
     compile 'com.segment.analytics.android:analytics:4.0.4'
-    compile 'com.swrve.segment:analytics-android-integration-swrve:1.0.1'
+    compile 'com.swrve.segment:analytics-android-integration-swrve:1.1.0'
 }
 ```
 
@@ -58,10 +58,10 @@ By default this integration pulls in the latest vanilla version of the Swrve SDK
 For example, if you wanted to use the Firebase flavored Swrve SDK:
 
 ```
-compile('com.swrve.segment:analytics-android-integration-swrve:1.0.1') {
+compile('com.swrve.segment:analytics-android-integration-swrve:1.1.0') {
     exclude group: 'com.swrve.sdk.android', module: 'swrve'
 }
-compile 'com.swrve.sdk.android:swrve-firebase:4.11.2'
+compile 'com.swrve.sdk.android:swrve-firebase:5.1.1'
 ```
 
 License

--- a/build.gradle
+++ b/build.gradle
@@ -20,8 +20,8 @@ group = project.bintrayGroupId
 version = project.bintrayPackageVersion
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion '25.0.2'
+    compileSdkVersion 27
+    buildToolsVersion '27.0.2'
 
     defaultConfig {
         minSdkVersion 14
@@ -40,7 +40,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.swrve.sdk.android:swrve:4.+'
+    compile 'com.swrve.sdk.android:swrve:5.+'
 
     compile 'com.segment.analytics.android:analytics:4.+'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 bintrayGroupId=com.swrve.segment
 bintrayArtifactId=analytics-android-integration-swrve
 bintrayPackageName=analytics-android-integration-swrve
-bintrayPackageVersion=1.0.1
+bintrayPackageVersion=1.1.0
 bintrayDescription=Swrve SDK for Segment analytics-android
 bintrayGithub=https://github.com/swrve-services/analytics-android-integration-swrve
 bintrayAuthor=Swrve Inc

--- a/src/main/java/com/swrve/segment/SwrveIntegration.java
+++ b/src/main/java/com/swrve/segment/SwrveIntegration.java
@@ -1,6 +1,5 @@
 package com.swrve.segment;
 
-import android.app.Activity;
 import android.app.Application;
 import com.swrve.sdk.config.SwrveConfig;
 import com.swrve.sdk.SwrveHelper;
@@ -73,20 +72,6 @@ public class SwrveIntegration extends Integration<Void> {
     String eventName = String.format("screen.%s", screen.event());
     SwrveSDK.event(eventName, screen.properties().toStringMap());
     logger.verbose("SwrveSDK.event(%s, %s)", eventName, screen.properties().toStringMap());
-  }
-
-  @Override
-  public void onActivityResumed(Activity activity) {
-    super.onActivityResumed(activity);
-    SwrveSDK.onResume(activity);
-    logger.verbose("SwrveSDK.onResume(%s)", activity);
-  }
-
-  @Override
-  public void onActivityPaused(Activity activity) {
-    super.onActivityPaused(activity);
-    SwrveSDK.onPause();
-    logger.verbose("SwrveSDK.onPause();");
   }
 
   @Override


### PR DESCRIPTION
Upgrading Swrve SDK from v4 to v5 causes a number of small breaking changes to this integration. Most significantly, the onResume() and onPause() methods were removed from the SDK
(see https://docs.swrve.com/release-notes/upgrade-guides/upgrading-to-5-0/android-sdk-5-0/), and this commit removes them from this integration. The integration's `buildToolsVersion` and `compileSdkVersion` have been upgraded from 25 to 27 to match v5 of the Swrve SDK.